### PR TITLE
fix concatenate effector

### DIFF
--- a/include/multicontact-api/scenario/contact-sequence.hpp
+++ b/include/multicontact-api/scenario/contact-sequence.hpp
@@ -1039,6 +1039,9 @@ struct ContactSequenceTpl : public serialization::Serializable<ContactSequenceTp
         }
       }
     }
+    if(first_phase == m_contact_phases.size())
+      throw std::invalid_argument("The contact sequence doesn't have any phase with an effector trajectory"
+                                  " for the given effector name");
     if(first_phase > 0){
       // add a first constant phase at the initial placement
       curve_SE3_ptr ptr_init(new SE3Curve_t(first_placement, first_placement, m_contact_phases.at(0).timeInitial(),

--- a/unittest/scenario.cpp
+++ b/unittest/scenario.cpp
@@ -1723,6 +1723,29 @@ BOOST_AUTO_TEST_CASE(contact_sequence_concatenate_effector_traj) {
   BOOST_CHECK(traj(8.).isApprox(traj_2->operator()(8.)));
   BOOST_CHECK(traj(2.5).isApprox(traj_0->operator()(2.)));
   BOOST_CHECK(traj(3.8).isApprox(traj_0->operator()(2.)));
+  BOOST_CHECK_THROW(cs1.concatenateEffectorTrajectories("test"), std::invalid_argument);
+
+  ContactPhase cp3 = ContactPhase(8, 12.);
+  cs1.append(cp3);
+  traj = cs1.concatenateEffectorTrajectories("right_leg");
+  BOOST_CHECK(traj.min() == 0.);
+  BOOST_CHECK(traj.max() == 12.);
+
+  ContactPhase cpm1 = ContactPhase(-2., 0.);
+  ContactSequence cs2 = ContactSequence(0);
+
+  cs2.append(cpm1);
+  cs2.append(cp0);
+  cs2.append(cp1);
+  cs2.append(cp2);
+  traj = cs2.concatenateEffectorTrajectories("right_leg");
+  BOOST_CHECK(traj.min() == -2.);
+  BOOST_CHECK(traj.max() == 8.);
+
+  cs2.append(cp3);
+  traj = cs2.concatenateEffectorTrajectories("right_leg");
+  BOOST_CHECK(traj.min() == -2.);
+  BOOST_CHECK(traj.max() == 12.);
 }
 
 BOOST_AUTO_TEST_CASE(contact_sequence_concatenate_force_traj) {


### PR DESCRIPTION
* The resulting trajectory have always the same time interval as the complete contact sequence
* Throw a readable error if the given effector name doesn't have any trajectory stored
Fix https://github.com/loco-3d/multicontact-api/issues/1
CI https://gepgitlab.laas.fr/pfernbac/multicontact-api/pipelines/9462