### PR TITLE
Fix an issue in `haveEffectorsTrajectories`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2020, CNRS Authors: Justin Carpentier <jcarpent@laas.fr>,
 # Guilhem Saurel
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 # Project properties
 set(PROJECT_ORG loco-3d)

--- a/include/multicontact-api/bindings/python/scenario/contact-sequence.hpp
+++ b/include/multicontact-api/bindings/python/scenario/contact-sequence.hpp
@@ -182,7 +182,7 @@ struct ContactSequencePythonVisitor
              "defined in each phase.")
         .def("haveEffectorsTrajectories", &CS::haveEffectorsTrajectories,
              cs_haveEffectorTrajectories_overloads(
-                 (bp::args("precision_treshold") =
+                 (bp::args("precision_threshold") =
                       Eigen::NumTraits<typename CS::Scalar>::dummy_precision(),
                   bp::args("use_rotation") = true),
                  "check that for each phase preceeding a contact creation,"

--- a/include/multicontact-api/scenario/contact-sequence.hpp
+++ b/include/multicontact-api/scenario/contact-sequence.hpp
@@ -778,58 +778,40 @@ struct ContactSequenceTpl
                     << " do not end at t_final in phase " << i << std::endl;
           return false;
         }
-        ContactPatch::SE3 pMax =
+        ContactPatch::SE3 pTrajMax =
             ContactPatch::SE3((*traj)(traj->max()).matrix());
-        if ((use_rotation && !pMax.isApprox(m_contact_phases.at(i + 1)
-                                                .contactPatches()
-                                                .at(eeName)
-                                                .placement(),
-                                            prec)) ||
-            (!pMax.translation().isApprox(m_contact_phases.at(i + 1)
-                                              .contactPatches()
-                                              .at(eeName)
-                                              .placement()
-                                              .translation(),
-                                          prec))) {
+        ContactPatch::SE3 pPhaseMax =
+            m_contact_phases.at(i + 1).contactPatches().at(eeName).placement();
+        if ((use_rotation &&
+             !(pTrajMax.toHomogeneousMatrix() - pPhaseMax.toHomogeneousMatrix()).isMuchSmallerThan(1.0, prec)) ||
+            !(pTrajMax.translation() - pPhaseMax.translation()).isMuchSmallerThan(1.0, prec)) {
           std::cout << "Effector trajectory for " << eeName
                     << " do not end at it's contact placement in the next "
                        "phase, for phase "
                     << i << std::endl;
           std::cout << "Last point : " << std::endl
-                    << pMax << std::endl
+                    << pTrajMax << std::endl
                     << "Next contact : " << std::endl
-                    << m_contact_phases.at(i + 1)
-                           .contactPatches()
-                           .at(eeName)
-                           .placement()
+                    << pPhaseMax
                     << std::endl;
           return false;
         }
         if (i > 0 && m_contact_phases.at(i - 1).isEffectorInContact(eeName)) {
-          ContactPatch::SE3 pMin =
-              ContactPatch::SE3((*traj)(traj->min()).matrix());
-          if ((use_rotation && !pMin.isApprox(m_contact_phases.at(i - 1)
-                                                  .contactPatches()
-                                                  .at(eeName)
-                                                  .placement(),
-                                              prec)) ||
-              (!pMin.translation().isApprox(m_contact_phases.at(i - 1)
-                                                .contactPatches()
-                                                .at(eeName)
-                                                .placement()
-                                                .translation(),
-                                            prec))) {
+          ContactPatch::SE3 pTrajMin =
+            ContactPatch::SE3((*traj)(traj->min()).matrix());
+          ContactPatch::SE3 pPhaseMin =
+              m_contact_phases.at(i -1).contactPatches().at(eeName).placement();
+          if ((use_rotation &&
+              !(pTrajMin.toHomogeneousMatrix() - pPhaseMin.toHomogeneousMatrix()).isMuchSmallerThan(1.0, prec)) ||
+              !(pTrajMin.translation() - pPhaseMin.translation()).isMuchSmallerThan(1.0, prec)) {
             std::cout << "Effector trajectory for " << eeName
                       << " do not start at it's contact placement in the "
                          "previous phase, for phase "
                       << i << std::endl;
             std::cout << "First point : " << std::endl
-                      << pMin << std::endl
+                      << pTrajMin << std::endl
                       << "Previous contact : " << std::endl
-                      << m_contact_phases.at(i - 1)
-                             .contactPatches()
-                             .at(eeName)
-                             .placement()
+                      << pPhaseMin
                       << std::endl;
             return false;
           }

--- a/include/multicontact-api/scenario/contact-sequence.hpp
+++ b/include/multicontact-api/scenario/contact-sequence.hpp
@@ -783,8 +783,10 @@ struct ContactSequenceTpl
         ContactPatch::SE3 pPhaseMax =
             m_contact_phases.at(i + 1).contactPatches().at(eeName).placement();
         if ((use_rotation &&
-             !(pTrajMax.toHomogeneousMatrix() - pPhaseMax.toHomogeneousMatrix()).isMuchSmallerThan(1.0, prec)) ||
-            !(pTrajMax.translation() - pPhaseMax.translation()).isMuchSmallerThan(1.0, prec)) {
+             !(pTrajMax.toHomogeneousMatrix() - pPhaseMax.toHomogeneousMatrix())
+                  .isMuchSmallerThan(1.0, prec)) ||
+            !(pTrajMax.translation() - pPhaseMax.translation())
+                 .isMuchSmallerThan(1.0, prec)) {
           std::cout << "Effector trajectory for " << eeName
                     << " do not end at it's contact placement in the next "
                        "phase, for phase "
@@ -792,18 +794,21 @@ struct ContactSequenceTpl
           std::cout << "Last point : " << std::endl
                     << pTrajMax << std::endl
                     << "Next contact : " << std::endl
-                    << pPhaseMax
-                    << std::endl;
+                    << pPhaseMax << std::endl;
           return false;
         }
         if (i > 0 && m_contact_phases.at(i - 1).isEffectorInContact(eeName)) {
           ContactPatch::SE3 pTrajMin =
-            ContactPatch::SE3((*traj)(traj->min()).matrix());
-          ContactPatch::SE3 pPhaseMin =
-              m_contact_phases.at(i -1).contactPatches().at(eeName).placement();
-          if ((use_rotation &&
-              !(pTrajMin.toHomogeneousMatrix() - pPhaseMin.toHomogeneousMatrix()).isMuchSmallerThan(1.0, prec)) ||
-              !(pTrajMin.translation() - pPhaseMin.translation()).isMuchSmallerThan(1.0, prec)) {
+              ContactPatch::SE3((*traj)(traj->min()).matrix());
+          ContactPatch::SE3 pPhaseMin = m_contact_phases.at(i - 1)
+                                            .contactPatches()
+                                            .at(eeName)
+                                            .placement();
+          if ((use_rotation && !(pTrajMin.toHomogeneousMatrix() -
+                                 pPhaseMin.toHomogeneousMatrix())
+                                    .isMuchSmallerThan(1.0, prec)) ||
+              !(pTrajMin.translation() - pPhaseMin.translation())
+                   .isMuchSmallerThan(1.0, prec)) {
             std::cout << "Effector trajectory for " << eeName
                       << " do not start at it's contact placement in the "
                          "previous phase, for phase "
@@ -811,8 +816,7 @@ struct ContactSequenceTpl
             std::cout << "First point : " << std::endl
                       << pTrajMin << std::endl
                       << "Previous contact : " << std::endl
-                      << pPhaseMin
-                      << std::endl;
+                      << pPhaseMin << std::endl;
             return false;
           }
         }

--- a/notebooks/1_basic_usage.ipynb
+++ b/notebooks/1_basic_usage.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/2_contact_sequence_creation.ipynb
+++ b/notebooks/2_contact_sequence_creation.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/3_load_from_file.ipynb
+++ b/notebooks/3_load_from_file.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
## Description

This PR robustify the test `contact_sequence.haveEffectorsTrajectories`.
In practice it works well except for:
- null transform.
- identity transform.

This is a well known issue from Eigen `isApprox` function. Hence the trick is to convert the two compared transforms into homogeneous matrices, subtract them and compare them to epsilon.

In essence I replace:
```
pinocchio SE3 a, b;
a.isApprox(b);
```
with:
```
pinocchio SE3 a, b;
(a.toHomogeneousMatrix() - b.toHomogeneousMatrix()).isMuchSmallerThan(1.0, prec)
```
Which is more verbose but more robust.
