### PR TITLE
Bump submodule and the default CMake version to ubuntu22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2020, CNRS Authors: Justin Carpentier <jcarpent@laas.fr>,
 # Guilhem Saurel
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.22.1)
 
 # Project properties
 set(PROJECT_ORG loco-3d)


### PR DESCRIPTION
I needed to bumb the submodule otherwize the minimum version of cmake were too low:
```
CMake Error at /workspaces/workspace_pal_estimator_ros2/build/multicontact_api/_deps/jrl-cmakemodules-src/base.cmake:145 (message):
JRL-CMakemodules require CMake >= 3.22. Please update your main
'cmake_minimum_required'
Call Stack (most recent call first):
CMakeLists.txt:56 (include)
```

I then took the liberty to bump the minimal version to the one of ubuntu22.04 as it's already an older OS. But still used on some real-time OS for robots.